### PR TITLE
Set initial login ID/password for demo.

### DIFF
--- a/app/lib/feature/auth/presentation/sign_in_page.dart
+++ b/app/lib/feature/auth/presentation/sign_in_page.dart
@@ -17,8 +17,8 @@ class SignInPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final formKey = useMemoized(() => GlobalKey<FormState>());
-    final emailController = useTextEditingController();
-    final passwordController = useTextEditingController();
+    final emailController = useTextEditingController(text: 'test@example.com');
+    final passwordController = useTextEditingController(text: 'pass1234');
     final passwordFocusNode = useFocusNode();
     final isHidePassword = useState(true);
     final isLoading = useState(false);


### PR DESCRIPTION
closes #27 

デモ用にログインID / パスワードの初期値をセットした